### PR TITLE
[Feature] JWT 인증 필터 및 CORS 설정 추가

### DIFF
--- a/src/main/java/com/cu2mber/gatewayservice/common/config/CorsConfig.java
+++ b/src/main/java/com/cu2mber/gatewayservice/common/config/CorsConfig.java
@@ -1,0 +1,79 @@
+package com.cu2mber.gatewayservice.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+/**
+ * Spring Cloud Gateway에서 전역 CORS(Cross-Origin Resource Sharing) 설정을 담당하는 구성 클래스입니다.
+ * <p>
+ * 이 설정은 브라우저 기반 클라이언트(프론트엔드)에서 발생하는 교차 출처 요청을
+ * Gateway 단에서 처리하기 위해 {@link CorsWebFilter}를 등록합니다.
+ * <p>
+ * Gateway는 WebFlux 기반이므로 Servlet 환경의 {@code CorsFilter}가 아닌
+ * {@code CorsWebFilter}를 사용해야 합니다.
+ *
+ * <h3>주요 설정 내용</h3>
+ * <ul>
+ *     <li>허용 Origin: front-service 컨테이너의 8090 포트</li>
+ *     <li>허용 HTTP Method: GET, POST, PUT, DELETE, PATCH, OPTIONS</li>
+ *     <li>허용 Header: Authorization, Content-Type</li>
+ *     <li>노출 Header: Authorization</li>
+ *     <li>Credentials 사용 여부: 사용하지 않음 (JWT 헤더 기반 인증)</li>
+ * </ul>
+ *
+ * <p>
+ * 이 설정을 통해 브라우저의 Preflight(OPTIONS) 요청이 정상적으로 처리되며,
+ * JWT 기반 인증 요청이 CORS 정책에 의해 차단되지 않도록 합니다.
+ * </p>
+ */
+@Configuration
+public class CorsConfig {
+
+    /**
+     * Gateway 전역 CORS 처리를 위한 {@link CorsWebFilter} Bean을 생성합니다.
+     * <p>
+     * 등록된 CORS 정책은 모든 경로("/**")에 적용되며,
+     * Authorization 헤더를 사용하는 JWT 기반 인증 구조에 맞게 구성되어 있습니다.
+     *
+     * @return 전역 CORS 정책이 적용된 {@link CorsWebFilter} 인스턴스
+     */
+    @Bean
+    public CorsWebFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // 허용할 프론트엔드 Origin (Docker 네트워크 기준)
+        config.setAllowedOrigins(List.of(
+                "http://front-service:8090"
+        ));
+
+        // 허용할 HTTP 메서드
+        config.setAllowedMethods(List.of(
+                "GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"
+        ));
+
+        // 허용할 요청 헤더
+        config.setAllowedHeaders(List.of(
+                "Authorization",
+                "Content-Type"
+        ));
+
+        // 클라이언트에 노출할 응답 헤더
+        config.setExposedHeaders(List.of(
+                "Authorization"
+        ));
+
+        // 쿠키 기반 인증을 사용하지 않으므로 credentials 비활성화
+        config.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source =
+                new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsWebFilter(source);
+    }
+}

--- a/src/main/java/com/cu2mber/gatewayservice/common/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/cu2mber/gatewayservice/common/filter/JwtAuthorizationFilter.java
@@ -8,41 +8,114 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+
 /**
- * JWT 토큰 기반 인증을 수행하는 Spring Cloud Gateway 필터 클래스입니다.
+ * Spring Cloud Gateway에서 JWT 기반 인증을 처리하는 Authorization 필터입니다.
+ *
  * <p>
- * 요청 헤더의 Authorization 값을 확인하고, "Bearer "로 시작하는 JWT 토큰을 추출하여
- * JwtProvider를 통해 검증합니다. 검증 실패 시 HTTP 401(Unauthorized)을 반환합니다.
+ * 이 필터는 모든 Gateway 요청에 대해 실행되며,
+ * 화이트리스트로 지정된 경로를 제외한 요청에 대해
+ * HTTP Authorization 헤더의 Bearer 토큰을 검증합니다.
+ * </p>
+ *
  * <p>
- * 이 필터는 각 Gateway 라우트에 적용되어 보호된 API 요청을 인증합니다.
+ * 토큰이 없거나, 형식이 올바르지 않거나, 검증에 실패할 경우
+ * HTTP 401(Unauthorized) 응답을 반환하고 요청을 차단합니다.
+ * </p>
+ *
+ * <p>
+ * 본 필터는 GatewayFilter 인터페이스를 구현하여
+ * 라우트 단위 또는 글로벌 필터로 적용될 수 있습니다.
+ * </p>
  */
 @Component
 @RequiredArgsConstructor
 public class JwtAuthorizationFilter implements GatewayFilter {
 
-    /** JWT 검증 및 토큰 관련 로직 제공 */
+    /**
+     * JWT 토큰의 유효성 검증 및 파싱 로직을 제공하는 Provider 클래스입니다.
+     *
+     * <p>
+     * 토큰 서명 검증, 만료 시간 확인 등의 책임을 가지며,
+     * 검증 실패 시 예외를 발생시킵니다.
+     * </p>
+     */
     private final JwtProvider jwtProvider;
 
     /**
-     * 요청을 필터링하고 JWT 인증을 수행합니다.
+     * JWT 인증 없이 접근을 허용할 API 경로 목록입니다.
      *
-     * @param exchange 현재 HTTP 요청/응답 정보
-     * @param chain    다음 필터 체인
-     * @return Mono<Void> 필터 체인의 완료 신호
+     * <p>
+     * 로그인, 회원가입, 토큰 발급/재발급과 같이
+     * 인증 이전 단계에서 호출되는 엔드포인트를 포함합니다.
+     * </p>
+     */
+    private static final List<String> WHITE_LIST = List.of(
+            "/auth/issue",
+            "/auth/refresh",
+            "/member/signup",
+            "/member/signin"
+    );
+
+    /**
+     * Gateway 요청을 가로채 JWT 인증을 수행합니다.
+     *
+     * <p>
+     * 처리 흐름은 다음과 같습니다:
+     * <ol>
+     *     <li>요청 URI 경로가 화이트리스트에 포함되는지 확인</li>
+     *     <li>화이트리스트 경로인 경우 인증 없이 다음 필터로 전달</li>
+     *     <li>Authorization 헤더에서 Bearer 토큰 추출</li>
+     *     <li>JwtProvider를 이용해 토큰 유효성 검증</li>
+     *     <li>검증 실패 시 401 Unauthorized 응답 반환</li>
+     * </ol>
+     * </p>
+     *
+     * @param exchange 현재 HTTP 요청과 응답 정보를 담고 있는 ServerWebExchange
+     * @param chain    Gateway 필터 체인
+     * @return Mono<Void> 요청 처리 완료를 나타내는 리액티브 타입
      */
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-        // JWT 토큰 검증 로직
+
+        String path = exchange.getRequest().getURI().getPath();
+
+        // 인증 없이 허용할 경로는 바로 통과
+        if (isWhiteList(path)) {
+            return chain.filter(exchange);
+        }
+
+        // Authorization 헤더에서 JWT 토큰 추출
         String authHeader = exchange.getRequest().getHeaders().getFirst("Authorization");
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             exchange.getResponse().setStatusCode(org.springframework.http.HttpStatus.UNAUTHORIZED);
             return exchange.getResponse().setComplete();
         }
 
-        String token = authHeader.substring(7);  // "Bearer "제거
+        // "Bearer " 접두사를 제거한 실제 토큰 값
+        String token = authHeader.substring(7);
 
-        jwtProvider.validateToken(token);
+        try {
+            // JWT 유효성 검증
+            jwtProvider.validateToken(token);
+        } catch (Exception e) {
+            // 토큰 검증 실패 시 요청 차단
+            exchange.getResponse().setStatusCode(org.springframework.http.HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
 
+        // 인증 성공 시 다음 필터 또는 라우트로 요청 전달
         return chain.filter(exchange);
+    }
+
+    /**
+     * 요청 경로가 인증 없이 접근 가능한 화이트리스트 경로인지 확인합니다.
+     *
+     * @param path 요청 URI 경로
+     * @return 화이트리스트에 포함된 경우 true, 그렇지 않으면 false
+     */
+    private boolean isWhiteList(String path) {
+        return WHITE_LIST.stream().anyMatch(path::startsWith);
     }
 }

--- a/src/main/java/com/cu2mber/gatewayservice/common/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/cu2mber/gatewayservice/common/filter/JwtAuthorizationFilter.java
@@ -54,8 +54,8 @@ public class JwtAuthorizationFilter implements GatewayFilter {
     private static final List<String> WHITE_LIST = List.of(
             "/auth/issue",
             "/auth/refresh",
-            "/member/signup",
-            "/member/signin"
+            "/members/signup",
+            "/members/signin"
     );
 
     /**


### PR DESCRIPTION
## 📌 개요
Gateway 서비스에 CORS 설정을 추가하고,  
JWT 인증 필터에 인증 제외(화이트리스트) 경로를 명시적으로 분리하였습니다.

---

## ✨ 변경 사항
- CORS 설정 클래스(`CorsConfig`) 신규 구현
- `JwtAuthorizationFilter`에 인증 제외 경로(화이트리스트) 추가
- JWT 검증 실패 시 401 응답을 반환하도록 예외 처리 보완

---

## 🛠 상세 내용
### 1. CORSConfig 추가
- `CorsWebFilter` 기반 CORS 설정 구현
- 프론트엔드 도메인에서 Gateway 접근 허용
- Authorization 헤더 허용 및 노출 설정

### 2. JwtAuthorizationFilter 수정
- 로그인 / 회원가입 등 인증이 필요 없는 API 경로를 화이트리스트로 분리
- 화이트리스트 경로는 JWT 검증 없이 통과
- JWT 검증 중 예외 발생 시 401 응답 반환

---

## 🔮 향후 계획
- 화이트리스트의 API 경로가 명확해지면 그에 맞춰 변경 예정
- 프론트엔드 도메인 경로가 확정되면 정확한 경로로 CORS 설정 수정 예정

---

## ✅ 변경사항 체크리스트
- [x] 인증 제외 API는 JWT 없이 정상 접근 가능
- [x] 인증 필요 API는 JWT 검증 후 통과
- [x] JWT 검증 실패 시 401 응답 반환
- [x] 프론트엔드 도메인에서 Gateway 접근 가능
- [x] 기존 라우팅 및 인증 로직에 영향 없음

---

## ⚠️ 참고 사항
- JWT 검증 로직 자체는 기존 구현을 그대로 사용하였습니다.
- Gateway는 JWT의 서명/만료 여부만 검증하며,  
  토큰 상태 관리는 Auth-Service에서 담당합니다.