### PR TITLE
[Feature] 헤더에 role, memberNo 추가

### DIFF
--- a/src/main/java/com/cu2mber/gatewayservice/common/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/cu2mber/gatewayservice/common/filter/JwtAuthorizationFilter.java
@@ -1,9 +1,11 @@
 package com.cu2mber.gatewayservice.common.filter;
 
 import com.cu2mber.gatewayservice.common.provider.JwtProvider;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
@@ -68,6 +70,9 @@ public class JwtAuthorizationFilter implements GatewayFilter {
      *     <li>화이트리스트 경로인 경우 인증 없이 다음 필터로 전달</li>
      *     <li>Authorization 헤더에서 Bearer 토큰 추출</li>
      *     <li>JwtProvider를 이용해 토큰 유효성 검증</li>
+     *     <li>검증된 JWT에서 Claims(memberNo, role 등) 추출</li>
+     *     <li>추출한 정보를 X-Role, X-Member-No 헤더로 주입</li>
+     *     <li>변경된 요청을 다음 필터 또는 라우트로 전달</li>
      *     <li>검증 실패 시 401 Unauthorized 응답 반환</li>
      * </ol>
      * </p>
@@ -99,14 +104,28 @@ public class JwtAuthorizationFilter implements GatewayFilter {
         try {
             // JWT 유효성 검증
             jwtProvider.validateToken(token);
+
+            // Claims 추출
+            Claims claims = jwtProvider.extractClaims(token);
+
+            // JWT Claims에서 사용자 권한 및 식별 정보 추출
+            String role = claims.get("role", String.class);
+            Long memberNo = claims.get("memberNo", Long.class);
+
+            // 내부 서비스로 전달할 사용자 정보 헤더 주입 (Header Propagation)
+            ServerHttpRequest request = exchange.getRequest()
+                    .mutate()
+                    .header("X-Role", role)
+                    .header("X-Member-No", String.valueOf(memberNo))
+                    .build();
+
+            return chain.filter(exchange.mutate().request(request).build());
+
         } catch (Exception e) {
             // 토큰 검증 실패 시 요청 차단
             exchange.getResponse().setStatusCode(org.springframework.http.HttpStatus.UNAUTHORIZED);
             return exchange.getResponse().setComplete();
         }
-
-        // 인증 성공 시 다음 필터 또는 라우트로 요청 전달
-        return chain.filter(exchange);
     }
 
     /**

--- a/src/main/java/com/cu2mber/gatewayservice/common/provider/JwtProvider.java
+++ b/src/main/java/com/cu2mber/gatewayservice/common/provider/JwtProvider.java
@@ -105,4 +105,8 @@ public class JwtProvider {
                 .parseClaimsJws(token)
                 .getBody();
     }
+
+    public Claims extractClaims(String token) {
+        return getClaims(token);
+    }
 }

--- a/src/main/java/com/cu2mber/gatewayservice/common/provider/JwtProvider.java
+++ b/src/main/java/com/cu2mber/gatewayservice/common/provider/JwtProvider.java
@@ -106,6 +106,13 @@ public class JwtProvider {
                 .getBody();
     }
 
+    /**
+     * JWT 토큰에서 Claims 정보를 추출하여 반환합니다.
+     *
+     * @param token Claims를 추출할 JWT 토큰
+     * @return Claims 토큰에 포함된 사용자 및 권한 정보
+     * @throws JwtException JWT 검증 또는 파싱 과정에서 오류가 발생한 경우
+     */
     public Claims extractClaims(String token) {
         return getClaims(token);
     }


### PR DESCRIPTION
## 📎 추가 사항
- notice-service의 요구사항에 따라  
  Gateway에서 JWT 검증 후 Claims에 포함된 사용자 정보(`role`, `memberNo`)를 추출하여  
  내부 서비스 호출 시 아래 헤더로 전달하도록 처리하였습니다.
  - `X-Role`
  - `X-Member-No`
